### PR TITLE
Add Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: perl6
+
+perl6:
+    - latest
+
+install:
+    - rakudobrew build-panda
+    - panda installdeps .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
+sudo: required
+
 language: perl6
 
 perl6:
     - latest
 
 install:
+    - sudo apt-get install icecast2
     - rakudobrew build-panda
     - panda installdeps .


### PR DESCRIPTION
This allows the project to be automatically built and tested with the latest version of Perl6 on the [Travis-CI](https://travis-ci.org) continuous integration service.
