### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -11,7 +11,7 @@
    "source-url" : "git@github.com:jonathanstowe/Audio-Icecast.git",
    "tags" : ["audio", "util", "icecast", "admin" ],
    "test-depends" : [ "CheckSocket", "Test" ],
-   "license" : "perl",
+   "license" : "Artistic-2.0",
    "auth" : "github:jonathanstowe",
    "provides" : {
       "Audio::Icecast" : "lib/Audio/Icecast.pm"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license